### PR TITLE
v0.3.0 release

### DIFF
--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -17,6 +17,10 @@ jobs:
         shell: pwsh
         run: |
           Install-Module -Name AsBuiltReport.Core -Repository PSGallery -Force
+      - name: Install AsBuiltReport.Diagram module
+        shell: pwsh
+        run: |
+          Install-Module -Name AsBuiltReport.Diagram -Repository PSGallery -Force
       - name: Test Module Manifest
         shell: pwsh
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 * Fix `Get-AbrAzSAQueue` and `Get-AbrAzSATable` - Use `New-AzStorageContext -UseConnectedAccount` for OAuth-based data plane access to resolve 403 Forbidden errors when storage account shared key access is disabled
 * Fix unhandled `Error while copying content to a stream` exception in `Invoke-AsBuiltReport.Microsoft.Azure` caused by `Get-AzTenant`, `Get-AzLocation`, and `Get-AzSubscription` being called without error handling after authentication; failures are now caught and reported as warnings
 * Fix `Get-AbrAzLoadBalancer` - Correct `LoadBalancerImage` to `Image` in all language files; the mismatched localization key caused the Load Balancer architecture diagram to fail rendering and fall back to the `ImageError` message
+* Fix `Release.yml` - Install `AsBuiltReport.Diagram` module prior to module manifest validation and publish steps; the missing required module caused the release pipeline to fail
 
 ## [0.2.0] - 2026-02-11
 


### PR DESCRIPTION
## Summary
- Merges v0.3.0 feature work (ASR, NetApp Files, Management Groups, diagrams, and more — see CHANGELOG) from dev into master
- Fixes the release pipeline: `Release.yml` was missing an install step for the required `AsBuiltReport.Diagram` module, causing manifest validation/publish to fail

## Test plan
- [ ] Confirm `Release.yml` run succeeds against this branch once merged and a release is published
- [ ] Confirm `Publish-Module` succeeds against PowerShell Gallery